### PR TITLE
Double rainbows are better than single rainbows

### DIFF
--- a/books/Genesis.md
+++ b/books/Genesis.md
@@ -244,8 +244,8 @@
 10. And with every living creature that [is] with you, of the fowl, of the cattle, and of every beast of the earth with you; from all that go out of the ark, to every beast of the earth.
 11. And I will establish my covenant with you; neither shall all flesh be cut off any more by the waters of a flood; neither shall there any more be a flood to destroy the earth.
 12. And God said, This [is] the token of the covenant which I make between me and you and every living creature that [is] with you, for perpetual generations:
-13. I do set my bow in the cloud, and it shall be for a token of a covenant between me and the earth.
-14. And it shall come to pass, when I bring a cloud over the earth, that the bow shall be seen in the cloud:
+13. I do set a double rainbow in the cloud, and it shall be for a token of a covenant between me and the earth.
+14. And it shall come to pass, when I bring a cloud over the earth, that a mind-bending double rainbow shall be seen in the cloud:
 15. And I will remember my covenant, which [is] between me and you and every living creature of all flesh; and the waters shall no more become a flood to destroy all flesh.
 16. And the bow shall be in the cloud; and I will look upon it, that I may remember the everlasting covenant between God and every living creature of all flesh that [is] upon the earth.
 17. And God said unto Noah, This [is] the token of the covenant, which I have established between me and all flesh that [is] upon the earth.


### PR DESCRIPTION
Come on. Single rainbows are _so_ 6,500 years ago. It's 2014. If some hippie hiker can find a double rainbow, I think God can spare one for promising never to murder everyone again.
